### PR TITLE
Trait cleanup

### DIFF
--- a/components/swap_traits/Cargo.toml
+++ b/components/swap_traits/Cargo.toml
@@ -18,8 +18,7 @@ scale-info = { version = "2", default-features = false, features = ["derive"], o
 name = "swap_traits"
 path = "lib.rs"
 crate-type = [
-	# Used for normal contract Wasm blobs.
-	"cdylib",
+	"rlib", # Just a library, not a contract.
 ]
 
 [features]

--- a/components/swap_traits/lib.rs
+++ b/components/swap_traits/lib.rs
@@ -1,3 +1,17 @@
-mod uniswap_v2_pair;
+//! Translations of the Uniswap v2 interfaces to Ink traits.
+//!
+//! # References
+//!
+//! - <https://github.com/Uniswap/v2-core/blob/master/contracts/interfaces/>
+//! - <https://docs.uniswap.org/protocol/V2/introduction>
+//! - <https://docs.uniswap.org/protocol/V2/concepts/protocol-overview/smart-contracts>
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
 mod uniswap_v2_callee;
 mod uniswap_v2_factory;
+mod uniswap_v2_pair;
+
+pub use uniswap_v2_callee::*;
+pub use uniswap_v2_factory::*;
+pub use uniswap_v2_pair::*;

--- a/components/swap_traits/uniswap_v2_callee.rs
+++ b/components/swap_traits/uniswap_v2_callee.rs
@@ -1,14 +1,18 @@
-
-#![cfg_attr(not(feature = "std"), no_std)]
+//! A callback for informing others about a swap.
+//!
+//! Seems to be used for flash swaps.
+//!
+//! # References
+//!
+//! - <https://github.com/Uniswap/v2-core/blob/master/contracts/interfaces/IUniswapV2Callee.sol>
+//! - <https://docs.uniswap.org/protocol/V2/guides/smart-contract-integration/using-flash-swaps>
 
 use ink_lang as ink;
 use ink_env::AccountId;
+use ink_prelude::vec::Vec;
 
-// Source of information: https://docs.uniswap.org/protocol/V2/guides/smart-contract-integration/using-flash-swaps
 #[ink::trait_definition]
 pub trait IUniswapV2Callee {
-
-    //All public functions must use this attribute
     #[ink(message)]
-    fn uniswap_v2_call(&self, sender: AccountId , amount0: u64, amount1: u64, data: Vec<u32>);
+    fn uniswap_v2_call(&mut self, sender: AccountId , amount0: u64, amount1: u64, data: Vec<u8>);
 }  

--- a/components/swap_traits/uniswap_v2_callee.rs
+++ b/components/swap_traits/uniswap_v2_callee.rs
@@ -7,12 +7,12 @@
 //! - <https://github.com/Uniswap/v2-core/blob/master/contracts/interfaces/IUniswapV2Callee.sol>
 //! - <https://docs.uniswap.org/protocol/V2/guides/smart-contract-integration/using-flash-swaps>
 
-use ink_lang as ink;
 use ink_env::AccountId;
+use ink_lang as ink;
 use ink_prelude::vec::Vec;
 
 #[ink::trait_definition]
 pub trait IUniswapV2Callee {
     #[ink(message)]
-    fn uniswap_v2_call(&mut self, sender: AccountId , amount0: u64, amount1: u64, data: Vec<u8>);
-}  
+    fn uniswap_v2_call(&mut self, sender: AccountId, amount0: u64, amount1: u64, data: Vec<u8>);
+}

--- a/components/swap_traits/uniswap_v2_factory.rs
+++ b/components/swap_traits/uniswap_v2_factory.rs
@@ -5,20 +5,19 @@
 //! - <https://github.com/Uniswap/v2-core/blob/master/contracts/interfaces/IUniswapV2Factory.sol>
 //! - <https://docs.uniswap.org/protocol/V2/reference/smart-contracts/factory>
 
-use ink_lang as ink;
 use ink_env::AccountId;
+use ink_lang as ink;
 
 // Note on access modifier (https://www.c-sharpcorner.com/article/variables-and-types-in-solidity/)
 
-// View functions are read only functions and do not modify the state of the block chain. 
-// In other words if you want to read data from the block chain one can use view. 
+// View functions are read only functions and do not modify the state of the block chain.
+// In other words if you want to read data from the block chain one can use view.
 // Getter method are by default view functions.
 // (https://cryptomarketpool.com/pure-and-view-in-solidity-smart-contracts/#:~:text=payable%20function%20modifiers.-,View,-functions%20are%20read)
 
 // An ink! message with a &self receiver may only read state whereas an ink!
-//  message with a &mut self receiver may mutate the contract’s storage. 
+//  message with a &mut self receiver may mutate the contract’s storage.
 // (https://paritytech.github.io/ink/ink_lang/attr.contract.html#:~:text=Note%3A-,An,-ink!%20message%20with)
-
 
 //TODO: Add this inside the contract
 //     #[ink(event)]
@@ -34,10 +33,8 @@ use ink_env::AccountId;
 //         log_value: u32 //1 for the first pair created, 2 for the second
 //     }
 
-
 #[ink::trait_definition]
 pub trait IUniswapV2Factory {
-
     #[ink(message)]
     fn fee_to(&self) -> AccountId;
 
@@ -52,16 +49,13 @@ pub trait IUniswapV2Factory {
 
     #[ink(message)]
     fn all_pairs_length(&self) -> u64;
-    
+
     #[ink(message)]
     fn create_pair(&mut self, token_a: AccountId, token_b: AccountId) -> AccountId;
 
     #[ink(message)]
-    fn sat_fee_to(&mut self,address: AccountId);
+    fn sat_fee_to(&mut self, address: AccountId);
 
     #[ink(message)]
     fn set_fee_to_setter(&mut self, address: AccountId);
-
 }
-
-

--- a/components/swap_traits/uniswap_v2_factory.rs
+++ b/components/swap_traits/uniswap_v2_factory.rs
@@ -1,6 +1,13 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+//! Manages token pairs.
+//!
+//! # References
+//!
+//! - <https://github.com/Uniswap/v2-core/blob/master/contracts/interfaces/IUniswapV2Factory.sol>
+//! - <https://docs.uniswap.org/protocol/V2/reference/smart-contracts/factory>
+
 use ink_lang as ink;
 use ink_env::AccountId;
+
 // Note on access modifier (https://www.c-sharpcorner.com/article/variables-and-types-in-solidity/)
 
 // View functions are read only functions and do not modify the state of the block chain. 
@@ -28,18 +35,12 @@ use ink_env::AccountId;
 //     }
 
 
-
 #[ink::trait_definition]
 pub trait IUniswapV2Factory {
 
-    //helpful docs: https://docs.uniswap.org/protocol/V2/reference/smart-contracts/factory
-    
-    #[ink(message)]
-    fn create_pair(&self, token_a: AccountId, token_b: AccountId) -> AccountId; 
-
-    
     #[ink(message)]
     fn fee_to(&self) -> AccountId;
+
     #[ink(message)]
     fn fee_to_setter(&self) -> AccountId;
 
@@ -47,20 +48,19 @@ pub trait IUniswapV2Factory {
     fn get_pair(&self, toekn_a: AccountId, token_b: AccountId) -> AccountId;
 
     #[ink(message)]
-    //TODO:Change log_value to U256
     fn all_pairs(&self, log_value: u64) -> AccountId;
 
     #[ink(message)]
-    //TODO: Change the return to U256
     fn all_pairs_length(&self) -> u64;
     
     #[ink(message)]
-    fn sat_fee_to(&self,address: AccountId);
+    fn create_pair(&mut self, token_a: AccountId, token_b: AccountId) -> AccountId;
 
     #[ink(message)]
-    fn set_fee_to_setter(&self, address: AccountId);
+    fn sat_fee_to(&mut self,address: AccountId);
 
-                
+    #[ink(message)]
+    fn set_fee_to_setter(&mut self, address: AccountId);
 
 }
 

--- a/components/swap_traits/uniswap_v2_pair.rs
+++ b/components/swap_traits/uniswap_v2_pair.rs
@@ -7,11 +7,10 @@
 //! - <https://docs.uniswap.org/protocol/V2/reference/smart-contracts/Pair-ERC-20>
 //! - <https://github.com/paritytech/ink/blob/master/examples/trait-erc20/lib.rs>
 
-use ink_lang as ink;
 use ink_env::AccountId;
+use ink_lang as ink;
 use ink_prelude::string::String;
 use ink_prelude::vec::Vec;
-
 
 // #[ink(event)]
 // struct Approval{
@@ -35,12 +34,10 @@ use ink_prelude::vec::Vec;
 //     value: Balance,
 // }
 
-
 #[ink::trait_definition]
 pub trait IUniswapV2Pair {
-
     #[ink(message)]
-    fn name(&self) -> String; 
+    fn name(&self) -> String;
 
     #[ink(message)]
     fn symbol(&self) -> String;
@@ -77,7 +74,16 @@ pub trait IUniswapV2Pair {
 
     // function permit(address owner, address spender, uint value, uint deadline, uint8 v, bytes32 r, bytes32 s) external;
     #[ink(message)]
-    fn permit(&mut self, owner: AccountId, spender: AccountId, value: u64, deadline: u64, v: u8, r: Vec<u8>, s: Vec<u8>);
+    fn permit(
+        &mut self,
+        owner: AccountId,
+        spender: AccountId,
+        value: u64,
+        deadline: u64,
+        v: u8,
+        r: Vec<u8>,
+        s: Vec<u8>,
+    );
 
     //event Mint, Burn, Swap, Sync
 
@@ -115,7 +121,7 @@ pub trait IUniswapV2Pair {
 
     // function swap(uint amount0Out, uint amount1Out, address to, bytes calldata data) external;
     #[ink(message)]
-    fn swap(&mut self, amount0_out: u64,amount1_out: u64, to: AccountId, data: Vec<u8> );
+    fn swap(&mut self, amount0_out: u64, amount1_out: u64, to: AccountId, data: Vec<u8>);
 
     #[ink(message)]
     fn skim(&mut self, to: AccountId);
@@ -126,5 +132,4 @@ pub trait IUniswapV2Pair {
     // function initialize(address, address) external;
     #[ink(message)]
     fn initialize(&mut self, address1: AccountId, address2: AccountId);
-
 }

--- a/components/swap_traits/uniswap_v2_pair.rs
+++ b/components/swap_traits/uniswap_v2_pair.rs
@@ -1,16 +1,16 @@
-// Useful docs: https://docs.uniswap.org/protocol/V2/reference/smart-contracts/pair
-
-
-//Big help from this: https://github.com/paritytech/ink/blob/master/examples/trait-erc20/lib.rs
-#![cfg_attr(not(feature = "std"), no_std)]
-
-use std::ops::Add;
+//! The Uniswap V2 token pair.
+//!
+//! # References
+//!
+//! - <https://github.com/Uniswap/v2-core/blob/master/contracts/interfaces/IUniswapV2Pair.sol>
+//! - <https://docs.uniswap.org/protocol/V2/reference/smart-contracts/pair>
+//! - <https://docs.uniswap.org/protocol/V2/reference/smart-contracts/Pair-ERC-20>
+//! - <https://github.com/paritytech/ink/blob/master/examples/trait-erc20/lib.rs>
 
 use ink_lang as ink;
 use ink_env::AccountId;
-
-//Following a discussion on discord with the polkadot support team, they recommend I just use this: https://paritytech.github.io/ink/ink_prelude/string/struct.String.html
-use ink_prelude::string::String;  
+use ink_prelude::string::String;
+use ink_prelude::vec::Vec;
 
 
 // #[ink(event)]
@@ -39,8 +39,6 @@ use ink_prelude::string::String;
 #[ink::trait_definition]
 pub trait IUniswapV2Pair {
 
-  
-
     #[ink(message)]
     fn name(&self) -> String; 
 
@@ -51,46 +49,39 @@ pub trait IUniswapV2Pair {
     fn decimals(&self) -> u8;
 
     #[ink(message)]
-    //TODO: Use U256
     fn total_supply(&self) -> u64;
 
     #[ink(message)]
-    //TODO: Use U256
     fn balance_of(&self, owner: AccountId) -> u64;
 
     #[ink(message)]
-    //TODO: Use U256
     fn allowance(&self, owner: AccountId, spender: AccountId) -> u64;
 
     #[ink(message)]
-    //TODO: Use U256
-    fn approve(&self, spender: AccountId, value: u64) -> bool;
+    fn approve(&mut self, spender: AccountId, value: u64) -> bool;
 
     #[ink(message)]
-    //TODO: Use U256
-    fn transfer(&self, to: AccountId, value: u64) -> bool;
+    fn transfer(&mut self, to: AccountId, value: u64) -> bool;
 
     #[ink(message)]
-    //TODO: Use U256
-    fn transfer_from(&self, from: AccountId, to: AccountId, value: u64) -> bool;
+    fn transfer_from(&mut self, from: AccountId, to: AccountId, value: u64) -> bool;
 
     #[ink(message)]
-    fn domain_separator(&self) -> Vec<u32>;
-    #[ink(message)]
-    fn permit_typehash(&self) -> Vec<u32>;
+    fn domain_separator(&self) -> Vec<u8>;
 
     #[ink(message)]
-    //TODO: Use U256
+    fn permit_typehash(&self) -> Vec<u8>;
+
+    #[ink(message)]
     fn nonces(&self, owner: AccountId) -> u64;
 
+    // function permit(address owner, address spender, uint value, uint deadline, uint8 v, bytes32 r, bytes32 s) external;
     #[ink(message)]
-    //TODO: Use U256
-    fn permit(&self, owner: AccountId, spender: AccountId, value: u64, deadline: u64, v: u8, r: Vec<u32>, s: Vec<u32>);
+    fn permit(&mut self, owner: AccountId, spender: AccountId, value: u64, deadline: u64, v: u8, r: Vec<u8>, s: Vec<u8>);
 
     //event Mint, Burn, Swap, Sync
 
     #[ink(message)]
-    //TODO: Use U256
     fn minimum_liquidity(&self) -> u64;
 
     #[ink(message)]
@@ -102,9 +93,9 @@ pub trait IUniswapV2Pair {
     #[ink(message)]
     fn token1(&self) -> AccountId;
 
-//     function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast);
+    // function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast);
     #[ink(message)]
-    fn get_reserves(&self) -> u64; // (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast);
+    fn get_reserves(&self) -> (u64, u64, u32);
 
     #[ink(message)]
     fn price_0_cumulative_last(&self) -> u64;
@@ -116,34 +107,24 @@ pub trait IUniswapV2Pair {
     fn k_last(&self) -> u64;
 
     #[ink(message)]
-    fn mint(&self, to: AccountId) -> u64;
+    fn mint(&mut self, to: AccountId) -> u64;
 
-//     function burn(address to) external returns (uint amount0, uint amount1);
+    // function burn(address to) external returns (uint amount0, uint amount1);
     #[ink(message)]
-    fn burn(&self) -> u64; //(uint amount0, uint amount1);
+    fn burn(&mut self) -> (u64, u64);
 
-//     function swap(uint amount0Out, uint amount1Out, address to, bytes calldata data) external;
+    // function swap(uint amount0Out, uint amount1Out, address to, bytes calldata data) external;
     #[ink(message)]
-    fn swap(&self, amount0Out: u64,amount1Out: u64, to: AccountId, data: Vec<u32> ); // bytes calldata data
-
-    #[ink(message)]
-    fn skim(&self, to: AccountId); 
+    fn swap(&mut self, amount0_out: u64,amount1_out: u64, to: AccountId, data: Vec<u8> );
 
     #[ink(message)]
-    fn sync(&self); 
+    fn skim(&mut self, to: AccountId);
 
-//     function initialize(address, address) external;
     #[ink(message)]
-    fn initialize(&self); //(address, address)
+    fn sync(&mut self);
 
-
-
-
-
-
-
-    
-
-
+    // function initialize(address, address) external;
+    #[ink(message)]
+    fn initialize(&mut self, address1: AccountId, address2: AccountId);
 
 }


### PR DESCRIPTION
Some notable things I did

- changed `Vec<u32>` to `Vec<u8>` to represent bytes types
- removed all the todos about u256 - there are so many we're just going to have to take another pass over these once we better understand the types in ink.
- changed the crate type to rlib since this is just a library - it is not compiled to a wasm contract
- added tuple return types where appropriate. some of these might want to be named types later on

cc @kris524 